### PR TITLE
Modified header name as per standard

### DIFF
--- a/data/benchmark-crawler-http.xml
+++ b/data/benchmark-crawler-http.xml
@@ -2372,7 +2372,7 @@
         <header name="http://localhost:5000/" value="BenchmarkTest00655"/>
     </benchmarkTest>
     <benchmarkTest URL="https://localhost:8443/benchmark/trustbound-00/BenchmarkTest00656" tcName="BenchmarkTest00656" tcType="SERVLET">
-        <header name="my_user_id" value="BenchmarkTest00656"/>
+        <header name="my-user-id" value="BenchmarkTest00656"/>
     </benchmarkTest>
     <benchmarkTest URL="https://localhost:8443/benchmark/deserialization-00/BenchmarkTest00657" tcName="BenchmarkTest00657" tcType="SERVLET">
         <header name="gASVNwAAAAAAAACMCF9fbWFpbl9flIwOc2FmZV90b19waWNrbGWUk5QpgZR9lCiMAWGUjANmb2-UjAFilEtjdWIu" value="BenchmarkTest00657"/>


### PR DESCRIPTION
Modified header name as per standard.
In this repo, the app is created with Flask in app.py and the pinned dependencies include both Flask and Werkzeug in requirements.txt.

Because header parsing happens in the Flask/Werkzeug request stack before the test code sees the request, headers containing underscores are dropped there, so BenchmarkTest00656 never receives my_user_id and the intended code path does not execute.